### PR TITLE
Add Dockerfile with alpine-boost

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Various Dockerfiles' sources for our Docker Hub images. See our repositories on 
 
 ## Docker Images
 
-|                  Image                  |  Base System  |           Arch           | Docker Hub Repository                                                                     | Description                                                |
-|:---------------------------------------:|:-------------:|:------------------------:|:------------------------------------------------------------------------------------------|:-----------------------------------------------------------|
-| [alpine-boost](alpine-boost/Dockerfile) | alpine 3.18.2 | linux/amd64, linux/arm64 | [coolstory/alpine-boost](https://hub.docker.com/repository/docker/coolstory/alpine-boost) | Light weight Linux system with installed C++ Boost library |
+|                  Image                  |  Base System  |           Arch           | Docker Hub Repository                                                                     | Description                                                        |
+|:---------------------------------------:|:-------------:|:------------------------:|:------------------------------------------------------------------------------------------|:-------------------------------------------------------------------|
+| [alpine-boost](alpine-boost/Dockerfile) | alpine 3.18.2 | linux/amd64, linux/arm64 | [coolstory/alpine-boost](https://hub.docker.com/repository/docker/coolstory/alpine-boost) | Light weight Linux system with installed C++ and C++ Boost library |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # various-containers
-Various Dockerfiles' sources for our Docker Hub images
+
+Various Dockerfiles' sources for our Docker Hub images. See our repositories on Docker Hub [here](https://hub.docker.com/u/coolstory).
+
+## Docker Images
+
+|                  Image                  |  Base System  |           Arch           | Docker Hub Repository                                                                     | Description                                                |
+|:---------------------------------------:|:-------------:|:------------------------:|:------------------------------------------------------------------------------------------|:-----------------------------------------------------------|
+| [alpine-boost](alpine-boost/Dockerfile) | alpine 3.18.2 | linux/amd64, linux/arm64 | [coolstory/alpine-boost](https://hub.docker.com/repository/docker/coolstory/alpine-boost) | Light weight Linux system with installed C++ Boost library |

--- a/alpine-boost/Dockerfile
+++ b/alpine-boost/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.18.2
 
-# Actualize repositories and install Boost library
+# Actualize repositories and install C++ tools and Boost library
 RUN apk update &&  \
     apk upgrade &&  \
-    apk add boost1.82 \
+    apk add gcc g++ make cmake boost1.82

--- a/alpine-boost/Dockerfile
+++ b/alpine-boost/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.18.2
+
+# Actualize repositories and install Boost library
+RUN apk update &&  \
+    apk upgrade &&  \
+    apk add boost1.82 \

--- a/alpine-boost/Dockerfile
+++ b/alpine-boost/Dockerfile
@@ -3,4 +3,4 @@ FROM alpine:3.18.2
 # Actualize repositories and install C++ tools and Boost library
 RUN apk update &&  \
     apk upgrade &&  \
-    apk add gcc g++ make cmake boost1.82
+    apk add gcc g++ make cmake boost1.82-dev

--- a/alpine-boost/README.md
+++ b/alpine-boost/README.md
@@ -6,4 +6,4 @@
 | Arch       |                                 linux/amd64, linux/arm64                                  |
 | Repository | [coolstory/alpine-boost](https://hub.docker.com/repository/docker/coolstory/alpine-boost) |
 
-Light weight Linux system with installed C++ Boost library. Boost version is 1.82.
+Light weight Linux system with installed C++ and C++ Boost library. Boost version is 1.82.

--- a/alpine-boost/README.md
+++ b/alpine-boost/README.md
@@ -1,0 +1,9 @@
+# alpine-boost
+
+| Property   |                                           Value                                           |
+|:-----------|:-----------------------------------------------------------------------------------------:|
+| Base image |                                       alpine:3.18.2                                       |
+| Arch       |                                 linux/amd64, linux/arm64                                  |
+| Repository | [coolstory/alpine-boost](https://hub.docker.com/repository/docker/coolstory/alpine-boost) |
+
+Light weight Linux system with installed C++ Boost library. Boost version is 1.82.

--- a/ubuntu-boost/Dockerfile
+++ b/ubuntu-boost/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:22.04
+
+# Actualize repositories and install Boost library
+RUN apt update &&  \
+    apt upgrade -y &&  \
+    apt install -y libboost-all-dev \

--- a/ubuntu-boost/Dockerfile
+++ b/ubuntu-boost/Dockerfile
@@ -1,6 +1,0 @@
-FROM ubuntu:22.04
-
-# Actualize repositories and install Boost library
-RUN apt update &&  \
-    apt upgrade -y &&  \
-    apt install -y libboost-all-dev \


### PR DESCRIPTION
Dockerfile starts from Alpine 3.18.2 and installs the C++ Boost library 1.82. Docker Image on Docker Hub is built with multiarch tag (amd64 + arm64). Also, image contains C++ tools such as `gcc`, `g++`, `make` and `cmake`.