### PR TITLE
Add push script

### DIFF
--- a/alpine-boost/Dockerfile
+++ b/alpine-boost/Dockerfile
@@ -3,4 +3,4 @@ FROM alpine:3.18.2
 # Actualize repositories and install C++ tools and Boost library
 RUN apk update &&  \
     apk upgrade &&  \
-    apk add gcc g++ make cmake boost1.82-dev
+    apk add git gcc g++ make cmake boost1.82-dev

--- a/alpine-boost/push.sh
+++ b/alpine-boost/push.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TAG=1.82
+
+docker buildx build --push \
+  --platform linux/amd64,linux/arm64/v8 \
+  --tag coolstory/alpine-boost:$TAG \
+  "$SCRIPT_DIR"


### PR DESCRIPTION
Added push script for the `alpine-boost` image.

Just run `push.sh` from any place and `alpine-boost` image will be build and pushed to the Docker Hub to our account _(check that you have access to the specified repository before)_.